### PR TITLE
Add Short GUID support (#3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 sudo: required
 dist: trusty
 
-dotnet: 2.1.400
+dotnet: 2.2.103
 mono:
   - 4.6.1
   - 4.8.1

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "projects": [ "src", "tests" ],
   "sdk": {
-    "version": "2.2.104"
+    "version": "2.2.103"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "projects": [ "src", "tests" ],
   "sdk": {
-    "version": "2.1.400"
+    "version": "2.2.104"
   }
 }

--- a/src/Giraffe.TokenRouter/Giraffe.TokenRouter.fsproj
+++ b/src/Giraffe.TokenRouter/Giraffe.TokenRouter.fsproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Giraffe" Version="2.0.*" />
+    <PackageReference Include="Giraffe" Version="3.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Giraffe.TokenRouter/TokenParsers.fs
+++ b/src/Giraffe.TokenRouter/TokenParsers.fs
@@ -96,46 +96,50 @@ let private floatParse (path : string) ipos fpos =
 let private guidMap = [| 3; 2; 1; 0; 5; 4; 7; 6; 8; 9; 10; 11; 12; 13; 14; 15 |]
 
 let private guidParse (path : string) ipos fpos =
-    let byteAry = Array.zeroCreate<byte>(16)
-    let mutable bytePos = 0
-    let mutable byteCur = 0uy
-    let mutable atHead  = true
-    let rec go pos =
-        if path.[pos] = '-' then // skip over '-' chars
-            if pos < fpos then go (pos + 1) else failure
-        else
-            let cv =  byte path.[pos]
+    if fpos - ipos = 21 then
+        try path.Substring(ipos, 22) |> ShortGuid.toGuid |> box |> rtrn
+        with _ -> failure
+    else
+        let byteAry = Array.zeroCreate<byte>(16)
+        let mutable bytePos = 0
+        let mutable byteCur = 0uy
+        let mutable atHead  = true
+        let rec go pos =
+            if path.[pos] = '-' then // skip over '-' chars
+                if pos < fpos then go (pos + 1) else failure
+            else
+                let cv =  byte path.[pos]
 
-            let value =
-                if  cv >= byte '0' then
-                    if cv <= byte '9' then cv - byte '0'
-                    elif cv >= byte 'A' then
-                        if cv <= byte 'F' then cv - byte 'A' + 10uy
-                        elif cv >= byte 'a' then
-                            if cv <= byte 'f' then cv - byte 'a' + 10uy
+                let value =
+                    if  cv >= byte '0' then
+                        if cv <= byte '9' then cv - byte '0'
+                        elif cv >= byte 'A' then
+                            if cv <= byte 'F' then cv - byte 'A' + 10uy
+                            elif cv >= byte 'a' then
+                                if cv <= byte 'f' then cv - byte 'a' + 10uy
+                                else 255uy
                             else 255uy
                         else 255uy
                     else 255uy
-                else 255uy
 
-            if value = 255uy then
-                failure
-            else
-                if atHead then
-                    byteCur <- value <<< 4
-                    atHead  <- false
-                    go (pos + 1)   // continue iter
+                if value = 255uy then
+                    failure
                 else
-                    byteAry.[guidMap.[bytePos]] <- byteCur ||| value
-                    if bytePos = 15 then
-                        Guid(byteAry) |> box |> rtrn
-                    else
-                        byteCur <- 0uy
-                        atHead  <- true
-                        bytePos <- bytePos + 1
+                    if atHead then
+                        byteCur <- value <<< 4
+                        atHead  <- false
                         go (pos + 1)   // continue iter
-    //Start Parse
-    go (ipos)
+                    else
+                        byteAry.[guidMap.[bytePos]] <- byteCur ||| value
+                        if bytePos = 15 then
+                            Guid(byteAry) |> box |> rtrn
+                        else
+                            byteCur <- 0uy
+                            atHead  <- true
+                            bytePos <- bytePos + 1
+                            go (pos + 1)   // continue iter
+        //Start Parse
+        go (ipos)
 
 let formatMap =
     dict [

--- a/src/Giraffe.TokenRouter/TokenRouter.fs
+++ b/src/Giraffe.TokenRouter/TokenRouter.fs
@@ -1,5 +1,6 @@
 module Giraffe.TokenRouter
 
+open FSharp.Control.Tasks.V2.ContextInsensitive
 open System.Collections.Generic
 open System.Text
 open Microsoft.FSharp.Reflection

--- a/src/Giraffe.TokenRouter/TokenRouter.fs
+++ b/src/Giraffe.TokenRouter/TokenRouter.fs
@@ -512,11 +512,13 @@ let private methodFns (meth:string) (fns:(Node->Node) list) (parent:Node) =
     parent.AddMidFn <| MethodMatch(meth,child)
     child
 
-let GET    fns = methodFns "GET"    fns
-let POST   fns = methodFns "POST"   fns
-let PUT    fns = methodFns "PUT"    fns
-let DELETE fns = methodFns "DELETE" fns
-let PATCH  fns = methodFns "PATCH"  fns
+let GET     fns = methodFns "GET"     fns
+let HEAD    fns = methodFns "HEAD"    fns
+let POST    fns = methodFns "POST"    fns
+let PUT     fns = methodFns "PUT"     fns
+let DELETE  fns = methodFns "DELETE"  fns
+let OPTIONS fns = methodFns "OPTIONS" fns
+let PATCH   fns = methodFns "PATCH"   fns
 
 ///**Description**
 /// HttpHandler funtion that accepts a list of route mapping functions and builds a route tree for fast processing of request routes

--- a/tests/Giraffe.TokenRouter.Tests/Giraffe.TokenRouter.Tests.fsproj
+++ b/tests/Giraffe.TokenRouter.Tests/Giraffe.TokenRouter.Tests.fsproj
@@ -8,13 +8,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.*" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.*" />
     <PackageReference Include="xunit" Version="2.4.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.*" />
     <PackageReference Include="NSubstitute" Version="3.1.*" />
-    <PackageReference Include="Giraffe" Version="2.0.*" />
+    <PackageReference Include="Giraffe" Version="3.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Giraffe.TokenRouter.Tests/TokenRouterTests.fs
+++ b/tests/Giraffe.TokenRouter.Tests/TokenRouterTests.fs
@@ -17,6 +17,7 @@ open Giraffe
 open Giraffe.Serialization
 open Giraffe.GiraffeViewEngine
 open Giraffe.TokenRouter
+open FSharp.Control.Tasks.V2.ContextInsensitive
 
 // ---------------------------------
 // XmlAssert
@@ -345,7 +346,7 @@ let ``POST "/text" with supported Accept header returns "good"`` () =
         | Some ctx ->
             let body = getBody ctx
             Assert.Equal(expected, body)
-            Assert.Equal("text/plain", ctx.Response |> getContentType)
+            Assert.Equal("text/plain; charset=utf-8", ctx.Response |> getContentType)
     }
 
 [<Fact>]
@@ -379,7 +380,7 @@ let ``POST "/json" with supported Accept header returns "json"`` () =
         | Some ctx ->
             let body = getBody ctx
             Assert.Equal(expected, body)
-            Assert.Equal("application/json", ctx.Response |> getContentType)
+            Assert.Equal("application/json; charset=utf-8", ctx.Response |> getContentType)
     }
 
 [<Fact>]
@@ -412,7 +413,7 @@ let ``POST "/either" with supported Accept header returns "either"`` () =
         | Some ctx ->
             let body = getBody ctx
             Assert.Equal(expected, body)
-            Assert.Equal("text/plain", ctx.Response |> getContentType)
+            Assert.Equal("text/plain; charset=utf-8", ctx.Response |> getContentType)
     }
 
 [<Fact>]
@@ -895,7 +896,7 @@ let ``GET "/person" returns rendered HTML view`` () =
         | Some ctx ->
             let body = (getBody ctx).Replace(Environment.NewLine, String.Empty)
             Assert.Equal(expected, body)
-            Assert.Equal("text/html", ctx.Response |> getContentType)
+            Assert.Equal("text/html; charset=utf-8", ctx.Response |> getContentType)
     }
 
 [<Fact>]
@@ -939,7 +940,7 @@ let ``Get "/auto" with Accept header of "application/json" returns JSON object``
         | Some ctx ->
             let body = getBody ctx
             Assert.Equal(expected, body)
-            Assert.Equal("application/json", ctx.Response |> getContentType)
+            Assert.Equal("application/json; charset=utf-8", ctx.Response |> getContentType)
     }
 
 [<Fact>]
@@ -983,7 +984,7 @@ let ``Get "/auto" with Accept header of "application/xml; q=0.9, application/jso
         | Some ctx ->
             let body = getBody ctx
             Assert.Equal(expected, body)
-            Assert.Equal("application/json", ctx.Response |> getContentType)
+            Assert.Equal("application/json; charset=utf-8", ctx.Response |> getContentType)
     }
 
 [<Fact>]
@@ -1037,7 +1038,7 @@ let ``Get "/auto" with Accept header of "application/xml" returns XML object`` (
         | Some ctx ->
             let body = getBody ctx
             XmlAssert.equals expected body
-            Assert.Equal("application/xml", ctx.Response |> getContentType)
+            Assert.Equal("application/xml; charset=utf-8", ctx.Response |> getContentType)
     }
 
 [<Fact>]
@@ -1091,7 +1092,7 @@ let ``Get "/auto" with Accept header of "application/xml, application/json" retu
         | Some ctx ->
             let body = getBody ctx
             XmlAssert.equals expected body
-            Assert.Equal("application/xml", ctx.Response |> getContentType)
+            Assert.Equal("application/xml; charset=utf-8", ctx.Response |> getContentType)
     }
 
 [<Fact>]
@@ -1135,7 +1136,7 @@ let ``Get "/auto" with Accept header of "application/json, application/xml" retu
         | Some ctx ->
             let body = getBody ctx
             Assert.Equal(expected, body)
-            Assert.Equal("application/json", ctx.Response |> getContentType)
+            Assert.Equal("application/json; charset=utf-8", ctx.Response |> getContentType)
     }
 
 [<Fact>]
@@ -1189,7 +1190,7 @@ let ``Get "/auto" with Accept header of "application/json; q=0.5, application/xm
         | Some ctx ->
             let body = getBody ctx
             XmlAssert.equals expected body
-            Assert.Equal("application/xml", ctx.Response |> getContentType)
+            Assert.Equal("application/xml; charset=utf-8", ctx.Response |> getContentType)
     }
 
 [<Fact>]
@@ -1243,7 +1244,7 @@ let ``Get "/auto" with Accept header of "application/json; q=0.5, application/xm
         | Some ctx ->
             let body = getBody ctx
             XmlAssert.equals expected body
-            Assert.Equal("application/xml", ctx.Response |> getContentType)
+            Assert.Equal("application/xml; charset=utf-8", ctx.Response |> getContentType)
     }
 
 [<Fact>]
@@ -1290,7 +1291,7 @@ Piercings: [|""ear""; ""nose""|]"
         | Some ctx ->
             let body = getBody ctx
             Assert.Equal(expected, body)
-            Assert.Equal("text/plain", ctx.Response |> getContentType)
+            Assert.Equal("text/plain; charset=utf-8", ctx.Response |> getContentType)
     }
 
 [<Fact>]
@@ -1334,7 +1335,7 @@ let ``Get "/auto" with Accept header of "text/html" returns a 406 response`` () 
             let body = getBody ctx
             Assert.Equal(406, getStatusCode ctx)
             Assert.Equal(expected, body)
-            Assert.Equal("text/plain", ctx.Response |> getContentType)
+            Assert.Equal("text/plain; charset=utf-8", ctx.Response |> getContentType)
     }
 
 [<Fact>]
@@ -1377,7 +1378,7 @@ let ``Get "/auto" without an Accept header returns a JSON object`` () =
         | Some ctx ->
             let body = getBody ctx
             Assert.Equal(expected, body)
-            Assert.Equal("application/json", ctx.Response |> getContentType)
+            Assert.Equal("application/json; charset=utf-8", ctx.Response |> getContentType)
     }
 
 [<Fact>]

--- a/tests/Giraffe.TokenRouter.Tests/TokenRouterTests.fs
+++ b/tests/Giraffe.TokenRouter.Tests/TokenRouterTests.fs
@@ -578,6 +578,31 @@ let ``GET "/foo/johndoe/FE9CFE1935D44EDC9A955D38C4D579BD" returns "Name: johndoe
         | Some ctx -> Assert.Equal(expected, getBody ctx, true)
     }
 
+[<Fact>]
+let ``GET "/foo/johndoe/Gf6c_tQ13E6alV04xNV5vQ" returns "Name: johndoe, Id: FE9CFE19-35D4-4EDC-9A95-5D38C4D579BD"`` () =
+    let ctx = Substitute.For<HttpContext>()
+    let app =
+        router notFound [
+            GET [
+                route   "/"       => text "Hello World"
+                route   "/foo"    => text "bar"
+                routef "/foo/%s/bar" text
+                routef "/foo/%s/%O" (fun (name, id: Guid) -> text (sprintf "Name: %s, Id: %O" name id))
+            ]
+        ]
+
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs (PathString("/foo/johndoe/Gf6c_tQ13E6alV04xNV5vQ")) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+    let expected = "Name: johndoe, Id: FE9CFE19-35D4-4EDC-9A95-5D38C4D579BD"
+
+    task {
+        let! result = app next ctx
+        match result with
+        | None     -> assertFailf "Result was expected to be %s" expected
+        | Some ctx -> Assert.Equal(expected, getBody ctx, true)
+    }
+
 // [<Fact>]
 // let ``POST "/POsT/1" returns "1"`` () =
 //     let ctx = Substitute.For<HttpContext>()


### PR DESCRIPTION
There are three different commits here (initial PR). I did them this way because I did 3 different things:

- The first updated the dependencies against the latest Giraffe (it was still targeting 2.0.x) and fixed the unit tests that change broke (Giraffe now put the character set as part of the content type).
- The second adds in the short GUID support, by simply calling out to Giraffe's implementation. It's one `if` statement on the GUID parsing logic, so hopefully that won't slow things down. I added a test for this third GUID format.
- The third adds the `HEAD` and `OPTIONS` route groupings; this will provide a workaround for #1 _(oops - think I said number 2 on the commit)_ in cases where the only reason they aren't under a verb is that one of those needs to be mapped. (This is an actual use case I have.) I also added a test for each verb to make sure that they worked as advertised.

At any rate, feel free to squash and/or cherry-pick as you see fit. Also, if something needs to be done differently, just let me know.